### PR TITLE
Update golangci-lint to v2.13

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -44,4 +44,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11
+          version: v2.13

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,7 +60,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan

--- a/optionsset_test.go
+++ b/optionsset_test.go
@@ -9,27 +9,28 @@ import (
 
 func TestLongFlag(t *testing.T) {
 	t.Parallel()
+	const flagName = "myflag"
 	for _, tt := range []struct {
 		name   string
 		expect string
 		conf   *OptionsSetConfig
 	}{
-		{"normal", "myflag", &OptionsSetConfig{
+		{"normal", flagName, &OptionsSetConfig{
 			FlagPrefix: "",
 			Flags: map[string]FlagConfig{
-				"myflag": {Long: "myflag"},
+				flagName: {Long: flagName},
 			},
 		}},
 		{"normal", "test-myflag", &OptionsSetConfig{
 			FlagPrefix: "test",
 			Flags: map[string]FlagConfig{
-				"myflag": {Long: "myflag"},
+				flagName: {Long: flagName},
 			},
 		}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if tt.expect != tt.conf.LongFlag("myflag") {
+			if tt.expect != tt.conf.LongFlag(flagName) {
 				t.Fail()
 			}
 		})


### PR DESCRIPTION
Bumps the golangci-lint version pinned in the repository's lint workflow(s) from v2.11 to v2.13.

Latest release: https://github.com/golangci/golangci-lint/releases/tag/v2.13.1

Signed-off-by: Biner <biner@carabiner.dev>
